### PR TITLE
Configure gulp TypeScript task to use `tsconfig.json`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -200,15 +200,16 @@ gulp.task("jQuery", function () {
 
 // !Task to compile TypeScript
 gulp.task("typescript", function () {
-  return gulp
-    .src(paths.ts.src)
+  const tsProject = ts.createProject("tsconfig.json"); 
+  return tsProject
+    .src()
     .pipe(
       plumber({
         errorHandler: notify.onError("Error: <%= error.message %>"),
       })
     )
     .pipe(sourcemaps.init()) // *Initialize sourcemap generation
-    .pipe(ts({ sourceMap: true }))
+    .pipe(tsProject()) // Compile TypeScript using tsconfig.json settings
     .pipe(concat("main.js")) // *Concatenate files
     .pipe(uglify()) // *Minify JS
     .pipe(sourcemaps.write(paths.ts.sourcemaps)) // *Write sourcemaps to specified folder


### PR DESCRIPTION
Updates the gulp typescript task to properly utilize the project's `tsconfig.json` settings via `ts.createProject()`. This resolves the ES2015+ compatibility issues by ensuring the correct TypeScript compiler options are applied during the build process.

Changes:
- Refactor typescript gulp task to use project configuration
- Replace inline compiler options with `tsconfig.json` reference
- Maintain existing sourcemap and minification pipeline

Fixes #3 